### PR TITLE
Airboss: SetMPWireCorrection to 15 for Supercarriers

### DIFF
--- a/l10n/DEFAULT/ATRM_Airboss.lua
+++ b/l10n/DEFAULT/ATRM_Airboss.lua
@@ -49,6 +49,7 @@ Washington:SetMaxSectionSize(4)
 Washington:SetMaxFlightsPerStack(1)
 Washington:SetRadioRelayLSO("Helo_Relay")
 Washington:SetRadioRelayMarshal("Tanker_Relay")
+Washington:SetMPWireCorrection(15)
 
 
 -- Create AIRBOSS object.
@@ -66,6 +67,7 @@ Nimitz:SetMaxSectionSize(4)
 Nimitz:SetMaxFlightsPerStack(1)
 Nimitz:SetRadioRelayLSO("Helo_Relay2")
 Nimitz:SetRadioRelayMarshal("Tanker_Relay2")
+Nimitz:SetMPWireCorrection(15)
 
 
 


### PR DESCRIPTION
This commit sets the wire correction value to 15.

Background:

Prior to this update, airboss wass off regarding which wire being
caught, and is currently reporting Actual wire +1

In our case, it appears that the default value of 12 is too low and
calculates own position further from the stern resulting in the
incorrect wire and as such, need to adjust the wire correction to a more
suitable value.

During testing on 2022-04-23 (event:
http://132virtualwing.org/index.php/page/event?id=1764) we determined
that a value of 15 reported the correct wire for all participants during
multiple traps across all available wires and bolters